### PR TITLE
Enable using UPS packages to `cmake` medulla

### DIFF
--- a/cmake/CheckEnvironment.cmake
+++ b/cmake/CheckEnvironment.cmake
@@ -7,7 +7,7 @@ macro(require_env_var VAR_NAME)
 endmacro()
 
 # Required for path setup
-require_env_var(MRB_INSTALL)
+#require_env_var(MRB_INSTALL)
 require_env_var(SBNANA_VERSION)
 require_env_var(SBNANAOBJ_VERSION)
 

--- a/cmake/CheckEnvironment.cmake
+++ b/cmake/CheckEnvironment.cmake
@@ -7,7 +7,6 @@ macro(require_env_var VAR_NAME)
 endmacro()
 
 # Required for path setup
-#require_env_var(MRB_INSTALL)
 require_env_var(SBNANA_VERSION)
 require_env_var(SBNANAOBJ_VERSION)
 

--- a/cmake/SetupEnvironment.cmake
+++ b/cmake/SetupEnvironment.cmake
@@ -1,9 +1,8 @@
 # cmake/SetupEnvironment.cmake
 
 # Set paths to external dependencies based on environment variables
-
-set(SBNANA_BASE "$ENV{MRB_INSTALL}/sbnana/$ENV{SBNANA_VERSION}")
-set(SBNANAOBJ_BASE "$ENV{MRB_INSTALL}/sbnanaobj/$ENV{SBNANAOBJ_VERSION}")
+set(SBNANA_BASE "$ENV{SBNANA_DIR}")
+set(SBNANAOBJ_BASE "$ENV{SBNANAOBJ_DIR}")
 
 set(SRPROXY_INC "$ENV{SRPROXY_INC}")
 set(OSCLIB_INC "$ENV{OSCLIB_INC}")

--- a/selection/CMakeLists.txt
+++ b/selection/CMakeLists.txt
@@ -2,8 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 project(cafana LANGUAGES CXX)
 
 # Central environment path resolution
-set(SBNANA_BASE "$ENV{MRB_INSTALL}/sbnana/$ENV{SBNANA_VERSION}")
-set(SBNANAOBJ_BASE "$ENV{MRB_INSTALL}/sbnanaobj/$ENV{SBNANAOBJ_VERSION}")
+set(SBNANA_BASE "${SBNANA_DIR}")
+set(SBNANAOBJ_BASE "${SBNANAOBJ_DIR}")
 
 # Set C++ Standard
 set(CMAKE_CXX_STANDARD 17)
@@ -22,10 +22,6 @@ set(SRPROXY_INC "$ENV{SRPROXY_INC}")
 set(OSCLIB_INC "$ENV{OSCLIB_INC}")
 set(OSCLIB_LIB "$ENV{OSCLIB_LIB}")
 set(EIGEN_INC "$ENV{EIGEN_INC}")
-set(SBNANA_INC "$ENV{MRB_INSTALL}/sbnana/$ENV{SBNANA_VERSION}/include")
-set(SBNANAOBJ_INC "$ENV{MRB_INSTALL}/sbnanaobj/$ENV{SBNANAOBJ_VERSION}/include")
-set(SBNANA_LIB "$ENV{MRB_INSTALL}/sbnana/$ENV{SBNANA_VERSION}/slf7.x86_64.e26.prof/lib")
-set(SBNANAOBJ_LIB "$ENV{MRB_INSTALL}/sbnanaobj/$ENV{SBNANAOBJ_VERSION}/slf7.x86_64.e26.prof/lib")
 
 # Library for the framework
 add_library(framework SHARED src/framework.cc)


### PR DESCRIPTION
**Awaiting `sbnanaobj` to support spine objects...**

Supports a simpler setup of medulla

```bash
setup sbnanaobj vXX_YY_ZZ -q e26:prof # > v10_00_05 
setup sbnana vXX_YY_ZZ -q e26:prof # > v10_01_01
setup cmake vXX_YY_ZZ # >= 3.17
```