### PR TITLE
Add minor utilities and particle enumerations

### DIFF
--- a/selection/include/cuts.h
+++ b/selection/include/cuts.h
@@ -197,7 +197,7 @@ namespace cuts
     {
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) != 2 && !pcuts::containment_cut(p))
+            if(pvars::pid(p) != pvars::kMuon && !pcuts::containment_cut(p))
                 return false;
         }
         return true;

--- a/selection/include/particle_utilities.h
+++ b/selection/include/particle_utilities.h
@@ -32,6 +32,18 @@ namespace utilities
     typedef std::tuple<double, double, double> three_vector;
 
     /**
+     * @brief Convert a caf::Proxy<float[3]> to a three_vector;
+     * @details caf::Proxy is an annoying type to deal with sometimes.
+     * Here we define a conversion between the two.
+     * @param proxyArr the caf::Proxy<float[3]> to convert
+     * @return the three_vector made of the caf::Proxy's three entries
+     */
+    three_vector to_three_vector(const caf::Proxy<float[3]>& proxyArr)
+    {
+      return std::make_tuple(proxyArr[0], proxyArr[1], proxyArr[2]);
+    }
+
+    /**
      * @brief Calculates the dot product of two three-vectors.
      * @details The dot product of two three-vectors is calculated as the sum
      * of the products of the corresponding components of the two vectors.
@@ -42,6 +54,20 @@ namespace utilities
     double dot_product(const three_vector & a, const three_vector & b)
     {
         return std::get<0>(a)*std::get<0>(b) + std::get<1>(a)*std::get<1>(b) + std::get<2>(a)*std::get<2>(b);
+    }
+
+    /**
+     * @brief Calculates the cross product of two three-vectors.
+     * @param a the first three-vector.
+     * @param b the second three-vector.
+     * @return the cross product of the two three-vectors.
+     */
+    three_vector cross_product(const three_vector & a, const three_vector & b)
+    {
+        double c0 = std::get<1>(a)*std::get<2>(b) - std::get<2>(a)*std::get<1>(b) 
+        double c1 = std::get<2>(a)*std::get<0>(b) - std::get<0>(a)*std::get<2>(b) 
+        double c2 = std::get<0>(a)*std::get<1>(b) - std::get<1>(a)*std::get<0>(b) 
+        return std::make_tuple(c0, c1, c2);
     }
 
     /**

--- a/selection/include/particle_variables.h
+++ b/selection/include/particle_variables.h
@@ -144,19 +144,19 @@ namespace pvars
         {
             switch(int(pvars::pid(p)))
             {
-                case 0:
+                case pvars::kPhoton:
                     mass = 0;
                     break;
-                case 1:
+                case pvars::kElectron:
                     mass = ELECTRON_MASS;
                     break;
-                case 2:
+                case pvars::kMuon:
                     mass = MUON_MASS;
                     break;
-                case 3:
+                case pvars::kPion:
                     mass = PION_MASS;
                     break;
-                case 4:
+                case pvars::kProton:
                     mass = PROTON_MASS;
                     break;
                 default:
@@ -741,7 +741,7 @@ namespace pvars
     template<class T>
     double photon_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[0];
+        return p.pid_scores[pvars::kPhoton];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, photon_softmax, photon_softmax);
 
@@ -757,7 +757,7 @@ namespace pvars
     template<class T>
     double electron_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[1];
+        return p.pid_scores[pvars::kElectron];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, electron_softmax, electron_softmax);
     
@@ -773,7 +773,7 @@ namespace pvars
     template<class T>
     double muon_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[2];
+        return p.pid_scores[pvars::kMuon];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, muon_softmax, muon_softmax);
 
@@ -789,7 +789,7 @@ namespace pvars
     template<class T>
     double pion_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[3];
+        return p.pid_scores[pvars::kPion];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, pion_softmax, pion_softmax);
 
@@ -805,7 +805,7 @@ namespace pvars
     template<class T>
     double proton_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[4];
+        return p.pid_scores[pvars::kProton];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, proton_softmax, proton_softmax);
 
@@ -821,7 +821,7 @@ namespace pvars
     template<class T>
     double mip_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[2] + p.pid_scores[3];
+        return p.pid_scores[pvars::kMuon] + p.pid_scores[pvars::kPion];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, mip_softmax, mip_softmax);
 
@@ -837,7 +837,7 @@ namespace pvars
     template<class T>
     double hadron_softmax(const caf::SRParticleDLPProxy & p)
     {
-        return p.pid_scores[3] + p.pid_scores[4];
+        return p.pid_scores[pvars::kPion] + p.pid_scores[pvars::kProton];
     }
     REGISTER_VAR_SCOPE(RegistrationScope::RecoParticle, hadron_softmax, hadron_softmax);
 

--- a/selection/include/scorers.h
+++ b/selection/include/scorers.h
@@ -15,6 +15,21 @@
 namespace pvars
 {
     /**
+     * @brief Enumeration for particle primary classification.
+     * @details This is the order that the particle ids occur in (most) vectors in the framework,
+     * with a unknown option to handle exceptions.
+     */
+    enum Particle_t
+    {
+        kPhoton   =  0,
+        kElectron =  1,
+        kMuon     =  2,
+        kPion     =  3,
+        kProton   =  4,
+        kUnknown  = -1
+    };
+
+    /**
      * @brief Function pointer for the primary classification function.
      * @details This function pointer is used to allow the user to configure
      * the primary classification function used in the analysis. The primary
@@ -103,7 +118,7 @@ namespace pvars
     double lax_muon_pid(const T & p)
     {
         double pid = std::numeric_limits<double>::quiet_NaN();
-        if(p.pid_scores[2] > 0.25)
+        if(p.pid_scores[pvars::kMuon] > 0.25)
             pid = 2;
         else
         {

--- a/selection/include/selectors.h
+++ b/selection/include/selectors.h
@@ -166,7 +166,7 @@ namespace selectors
     template<class T>
     size_t leading_photon(const T & obj)
     {
-        return leading_particle_index(obj, 0);
+        return leading_particle_index(obj, pvars::kPhoton);
     }
     REGISTER_SELECTOR(leading_photon, leading_photon);
 
@@ -182,7 +182,7 @@ namespace selectors
     template<class T>
     size_t leading_electron(const T & obj)
     {
-        return leading_particle_index(obj, 1);
+        return leading_particle_index(obj, pvars::kElectron);
     }
     REGISTER_SELECTOR(leading_electron, leading_electron);
 
@@ -197,7 +197,7 @@ namespace selectors
     template<class T>
     size_t leading_muon(const T & obj)
     {
-        return leading_particle_index(obj, 2);
+        return leading_particle_index(obj, pvars::kMuon);
     }
     REGISTER_SELECTOR(leading_muon, leading_muon);
 
@@ -212,7 +212,7 @@ namespace selectors
     template<class T>
     size_t leading_pion(const T & obj)
     {
-        return leading_particle_index(obj, 3);
+        return leading_particle_index(obj, pvars::kPion);
     }
     REGISTER_SELECTOR(leading_pion, leading_pion);
     
@@ -227,7 +227,7 @@ namespace selectors
     template<class T>
     size_t leading_proton(const T & obj)
     {
-        return leading_particle_index(obj, 4);
+        return leading_particle_index(obj, pvars::kProton);
     }
     REGISTER_SELECTOR(leading_proton, leading_proton);
 }

--- a/selection/include/variables.h
+++ b/selection/include/variables.h
@@ -132,7 +132,7 @@ namespace vars
             if(pcuts::final_state_signal(p))
             {
                 energy += pvars::energy(p);
-                if(pvars::pid(p) == 4) energy -= pvars::mass(p) - PROTON_BINDING_ENERGY;
+                if(pvars::pid(p) == pvars::kProton) energy -= pvars::mass(p) - PROTON_BINDING_ENERGY;
             }
         }
         return energy/1000.0;
@@ -159,7 +159,7 @@ namespace vars
             if(pcuts::final_state_signal(p))
             {
                 energy += pvars::energy(p);
-                if(pvars::pid(p) == 4) energy -= PROTON_MASS - PROTON_BINDING_ENERGY;
+                if(pvars::pid(p) == pvars::kProton) energy -= PROTON_MASS - PROTON_BINDING_ENERGY;
             }
             else if(pcuts::is_primary(p))
                 energy += p.calo_ke;
@@ -330,14 +330,14 @@ namespace vars
             if(pcuts::final_state_signal(p))
             {
                 // Find the leading charged lepton and proton
-                if((pvars::pid(p) == 1 || pvars::pid(p) == 2) && pvars::ke(p) > l_ke)
+                if((pvars::pid(p) == pvars::kElectron || pvars::pid(p) == pvars::kMuon) && pvars::ke(p) > l_ke)
                 {
                     l_ke = pvars::ke(p);
                     utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
                     utilities::three_vector vtx = {pvars::start_x(p), pvars::start_y(p), pvars::start_z(p)};
                     l_pt = utilities::transverse_momentum(momentum, vtx);
                 }
-                else if(pvars::pid(p) == 4 && pvars::ke(p) > p_ke)
+                else if(pvars::pid(p) == pvars::kProton && pvars::ke(p) > p_ke)
                 {
                     p_ke = pvars::ke(p);
                     utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
@@ -382,7 +382,7 @@ namespace vars
                 utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
                 utilities::three_vector vtx = {pvars::start_x(p), pvars::start_y(p), pvars::start_z(p)};
                 utilities::three_vector this_pt = utilities::transverse_momentum(momentum, vtx);
-                if(pvars::pid(p) == 1 || pvars::pid(p) == 2)
+                if(pvars::pid(p) == pvars::kElectron || pvars::pid(p) == pvars::kMuon)
                     lepton_pt = this_pt;
                 // The total hadronic system is treated as a single object.
                 else if(pvars::pid(p) > 2)
@@ -421,7 +421,7 @@ namespace vars
                 utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
                 utilities::three_vector vtx = {pvars::start_x(p), pvars::start_y(p), pvars::start_z(p)};
                 utilities::three_vector this_pt = utilities::transverse_momentum(momentum, vtx);
-                if(pvars::pid(p) == 1 || pvars::pid(p) == 2)
+                if(pvars::pid(p) == pvars::kElectron || pvars::pid(p) == pvars::kMuon)
                     lepton_pt = this_pt;
                 total_pt = utilities::add(total_pt, this_pt);
             }
@@ -457,7 +457,7 @@ namespace vars
                 utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
                 utilities::three_vector vtx = {pvars::start_x(p), pvars::start_y(p), pvars::start_z(p)};
                 utilities::three_vector this_pl = utilities::longitudinal_momentum(momentum, vtx);
-                if(pvars::pid(p) == 1 || pvars::pid(p) == 2)
+                if(pvars::pid(p) == pvars::kElectron || pvars::pid(p) == pvars::kMuon)
                     lepton_pl = this_pl;
                 // The total hadronic system is treated as a single object.
                 else if(pvars::pid(p) > 2)
@@ -493,14 +493,14 @@ namespace vars
             if(pcuts::final_state_signal(p))
             {
                 // Find the leading charged lepton and proton
-                if((pvars::pid(p) == 1 || pvars::pid(p) == 2) && pvars::ke(p) > l_ke)
+                if((pvars::pid(p) == pvars::kElectron || pvars::pid(p) == pvars::kMuon) && pvars::ke(p) > l_ke)
                 {
                     l_ke = pvars::ke(p);
                     utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
                     utilities::three_vector vtx = {pvars::start_x(p), pvars::start_y(p), pvars::start_z(p)};
                     l_pl = utilities::longitudinal_momentum(momentum, vtx);
                 }
-                else if(pvars::pid(p) == 4 && pvars::ke(p) > p_ke)
+                else if(pvars::pid(p) == pvars::kProton && pvars::ke(p) > p_ke)
                 {
                     p_ke = pvars::ke(p);
                     utilities::three_vector momentum = {pvars::px(p), pvars::py(p), pvars::pz(p)};
@@ -595,7 +595,7 @@ namespace vars
         size_t count(0);
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) == 0 && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
+            if(pvars::pid(p) == pvars::kPhoton && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
                 ++count;
         }
         return count;
@@ -623,7 +623,7 @@ namespace vars
         size_t count(0);
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) == 1 && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
+            if(pvars::pid(p) == pvars::kElectron && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
                 ++count;
         }
         return count;
@@ -651,7 +651,7 @@ namespace vars
         size_t count(0);
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) == 2 && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
+            if(pvars::pid(p) == pvars::kMuon && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
                 ++count;
         }
         return count;
@@ -679,7 +679,7 @@ namespace vars
         size_t count(0);
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) == 3 && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
+            if(pvars::pid(p) == pvars::kPion && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
                 ++count;
         }
         return count;
@@ -707,7 +707,7 @@ namespace vars
         size_t count(0);
         for(const auto & p : obj.particles)
         {
-            if(pvars::pid(p) == 4 && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
+            if(pvars::pid(p) == pvars::kProton && pvars::primary_classification(p) && pvars::ke(p) >= params[0])
                 ++count;
         }
         return count;


### PR DESCRIPTION
This PR adds two main, but minor, features. Both related to particle-level analysis.

1. Add functions for constructing a `utilities::three_vector` from a `caf::Proxy` array (which makes it easier to directly grab the vertex, direction, etc. from a particle in the CAFs) and performing the cross product on two vectors ([useful in some circumstances comparing two vectors](https://en.wikipedia.org/wiki/Skew_lines#Formulas), but also complements including the dot product)
2. Add enum for particle types. This increases legibility of some function as the particle type can be read directly instead of having to memorize a specific order. It also make it easier for users to write their own functions with these types for the same reason.