### PR TITLE
Feature/biselectors

### DIFF
--- a/selection/include/biselectors.h
+++ b/selection/include/biselectors.h
@@ -1,0 +1,76 @@
+/**
+ * @file biselectors.h
+ * @brief Header file for biselectors used in the SPINE analysis framework.
+ * @details This file contains definitions of biselectors which can be used
+ * to select a pair of particles (by index) within an interaction. This is a
+ * useful feature for reducing down a collection of particles in a final state
+ * to just a pair, which allows a user to broadcast a two-particle variable
+ * "upwards" to the interaction level.
+ * @author mueller@fnal.gov
+ */
+#ifndef BISELECTORS_H
+#define BISELECTORS_H
+#include <vector>
+#include <utility>
+
+#include "framework.h"
+#include "include/selectors.h"
+
+/**
+ * @namespace biselectors
+ * @brief Namespace for organizing biselectors which act on interactions.
+ * @details This namespace is intended to be used for organizing biselectors
+ * which act on interactions. Each biselector is implemented as a function
+ * which takes an interaction object as an argument and returns a pair of
+ * indices corresponding to the two selected particles. The function should
+ * be templated on the type of interaction object if the biselector is
+ * intended to be used on both true and reconstructed interactions.
+ */
+namespace biselectors
+{
+    /**
+     * @brief Selects the leading muon and leading proton.
+     * @details The leading muon and proton are defined as the particles with
+     * the highest kinetic energy of their respective types.
+     * @tparam T the type of interaction (true or reco).
+     * @param obj the interaction to operate on.
+     * @return pair of indices: {leading_muon, leading_proton}.
+     */
+    template<class T>
+    std::pair<size_t, size_t> muon_proton(const T & obj)
+    {
+        return { selectors::leading_muon(obj), selectors::leading_proton(obj) };
+    }
+    REGISTER_BISELECTOR(muon_proton, muon_proton);
+
+    /**
+     * @brief Selects the two longest tracks in the interaction.
+     * @details The longest and second longest tracks are defined by their
+     * track length as calculated upstream in SPINE.
+     * @tparam T the type of interaction (true or reco).
+     * @param obj the interaction to operate on.
+     * @return pair of indices: {longest_track, second_longest_track}.
+     */
+    template<class T>
+    std::pair<size_t, size_t> two_longest_tracks(const T & obj)
+    {
+        return { selectors::longest_track(obj), selectors::second_longest_track(obj) };
+    }
+    REGISTER_BISELECTOR(two_longest_tracks, two_longest_tracks);
+
+    /**
+     * @brief Selects the leading muon and leading pion.
+     * @details The leading muon and pion are defined as the particles with
+     * the highest kinetic energy of their respective types.
+     * @tparam T the type of interaction (true or reco).
+     * @param obj the interaction to operate on.
+     * @return pair of indices: {leading_muon, leading_pion}.
+     */
+    template<class T>
+    std::pair<size_t, size_t> muon_pion(const T & obj)
+    {
+        return { selectors::leading_muon(obj), selectors::leading_pion(obj) };
+    }
+    REGISTER_BISELECTOR(muon_pion, muon_pion);
+}
+#endif // BISELECTORS_H

--- a/selection/include/bivariables.h
+++ b/selection/include/bivariables.h
@@ -40,9 +40,9 @@ namespace bvars
     double opening_angle(const T & a, const T & b)
     {
         return std::acos(
-            a.start_dir[0] * b.start_dir[0] +
-            a.start_dir[1] * b.start_dir[1] +
-            a.start_dir[2] * b.start_dir[2]
+            pvars::start_dir_x(a) * pvars::start_dir_x(b) +
+            pvars::start_dir_y(a) * pvars::start_dir_y(b) +
+            pvars::start_dir_z(a) * pvars::start_dir_z(b)
         );
     }
     REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, opening_angle, opening_angle);

--- a/selection/include/bivariables.h
+++ b/selection/include/bivariables.h
@@ -1,0 +1,105 @@
+/**
+ * @file bivariables.h
+ * @brief Header file for definitions of bivariables which act on pairs of
+ * particles.
+ * @details This file contains definitions of bivariables which act on pairs
+ * of particles. Each bivariable is implemented as a function which takes two
+ * particle objects as arguments and returns a double. These variables are
+ * intended to be used to define observables that depend on the relationship
+ * between two particles in an interaction.
+ * @author mueller@fnal.gov
+ */
+#ifndef BIVARIABLES_H
+#define BIVARIABLES_H
+#include <cmath>
+
+#include "include/particle_variables.h"
+#include "framework.h"
+
+/**
+ * @namespace bvars
+ * @brief Namespace for organizing variables which act on pairs of particles.
+ * @details This namespace is intended to be used for organizing variables which
+ * act on pairs of particles. Each variable is implemented as a function which
+ * takes two particle objects as arguments and returns a double. The function
+ * should be templated on the type of particle object if the variable is
+ * intended to be used on both true and reconstructed particles.
+ */
+namespace bvars
+{
+    /**
+     * @brief Opening angle between two particles.
+     * @details Computes the arccosine of the dot product of the two
+     * particles' start direction vectors.
+     * @tparam T the type of particle (true or reco).
+     * @param a the first particle.
+     * @param b the second particle.
+     * @return the opening angle in radians.
+     */
+    template<class T>
+    double opening_angle(const T & a, const T & b)
+    {
+        return std::acos(
+            a.start_dir[0] * b.start_dir[0] +
+            a.start_dir[1] * b.start_dir[1] +
+            a.start_dir[2] * b.start_dir[2]
+        );
+    }
+    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, opening_angle, opening_angle);
+
+    /**
+     * @brief Invariant mass of two particles.
+     * @details Computes the invariant mass of two particles using their
+     * energy and momentum components.
+     * @tparam T the type of particle (true or reco).
+     * @param a the first particle.
+     * @param b the second particle.
+     * @return the invariant mass in MeV.
+     */
+    template<class T>
+    double invariant_mass(const T & a, const T & b)
+    {
+        double ea = pvars::energy(a), eb = pvars::energy(b);
+        double px = pvars::px(a) + pvars::px(b);
+        double py = pvars::py(a) + pvars::py(b);
+        double pz = pvars::pz(a) + pvars::pz(b);
+        double e  = ea + eb;
+        double m2 = e*e - px*px - py*py - pz*pz;
+        return (m2 > 0) ? std::sqrt(m2) : 0.0;
+    }
+    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, invariant_mass, invariant_mass);
+
+    /**
+     * @brief Sum of kinetic energies of two particles.
+     * @tparam T the type of particle (true or reco).
+     * @param a the first particle.
+     * @param b the second particle.
+     * @return the sum of kinetic energies.
+     */
+    template<class T>
+    double ke_sum(const T & a, const T & b)
+    {
+        return pvars::ke(a) + pvars::ke(b);
+    }
+    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, ke_sum, ke_sum);
+
+    /**
+     * @brief Distance between start points of two particles.
+     * @details Computes the Euclidean distance between the start points
+     * of two particles.
+     * @tparam T the type of particle (true or reco).
+     * @param a the first particle.
+     * @param b the second particle.
+     * @return the Euclidean distance between start points.
+     */
+    template<class T>
+    double start_distance(const T & a, const T & b)
+    {
+        double dx = pvars::start_x(a) - pvars::start_x(b);
+        double dy = pvars::start_y(a) - pvars::start_y(b);
+        double dz = pvars::start_z(a) - pvars::start_z(b);
+        return std::sqrt(dx*dx + dy*dy + dz*dz);
+    }
+    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, start_distance, start_distance);
+}
+#endif // BIVARIABLES_H

--- a/selection/include/bivariables.h
+++ b/selection/include/bivariables.h
@@ -48,42 +48,6 @@ namespace bvars
     REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, opening_angle, opening_angle);
 
     /**
-     * @brief Invariant mass of two particles.
-     * @details Computes the invariant mass of two particles using their
-     * energy and momentum components.
-     * @tparam T the type of particle (true or reco).
-     * @param a the first particle.
-     * @param b the second particle.
-     * @return the invariant mass in MeV.
-     */
-    template<class T>
-    double invariant_mass(const T & a, const T & b)
-    {
-        double ea = pvars::energy(a), eb = pvars::energy(b);
-        double px = pvars::px(a) + pvars::px(b);
-        double py = pvars::py(a) + pvars::py(b);
-        double pz = pvars::pz(a) + pvars::pz(b);
-        double e  = ea + eb;
-        double m2 = e*e - px*px - py*py - pz*pz;
-        return (m2 > 0) ? std::sqrt(m2) : 0.0;
-    }
-    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, invariant_mass, invariant_mass);
-
-    /**
-     * @brief Sum of kinetic energies of two particles.
-     * @tparam T the type of particle (true or reco).
-     * @param a the first particle.
-     * @param b the second particle.
-     * @return the sum of kinetic energies.
-     */
-    template<class T>
-    double ke_sum(const T & a, const T & b)
-    {
-        return pvars::ke(a) + pvars::ke(b);
-    }
-    REGISTER_BIVAR_SCOPE(RegistrationScope::BothParticle, ke_sum, ke_sum);
-
-    /**
      * @brief Distance between start points of two particles.
      * @details Computes the Euclidean distance between the start points
      * of two particles.

--- a/selection/include/framework.h
+++ b/selection/include/framework.h
@@ -14,6 +14,7 @@
 #include <functional>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 
 #include "sbnana/CAFAna/Core/MultiVar.h"
 #include "configuration.h"
@@ -156,6 +157,41 @@ using SelectorFactory = std::function<SelectorFn<EventT>(const std::vector<doubl
 template<typename EventT>
 using SelectorFactoryRegistry = Registry<SelectorFactory<EventT>>;
 
+//-----------------------------------------------------------------------------
+// 4) Biselector and Bivariable function registries
+//-----------------------------------------------------------------------------
+/**
+ * @brief Alias for BiSelector functions with signature
+ * std::pair<size_t, size_t>(const EventT&).
+ */
+template<typename EventT>
+using BiSelectorFn = std::function<std::pair<size_t, size_t>(const EventT&)>;
+
+/**
+ * @brief A factory function: given params, returns a BiSelectorFn<EventT>
+ */
+template<typename EventT>
+using BiSelectorFactory = std::function<BiSelectorFn<EventT>(const std::vector<double>&)>;
+
+template<typename EventT>
+using BiSelectorFactoryRegistry = Registry<BiSelectorFactory<EventT>>;
+
+/**
+ * @brief Alias for BiVariable functions with signature
+ * double(const ParticleT&, const ParticleT&).
+ */
+template<typename ParticleT>
+using BiVarFn = std::function<double(const ParticleT&, const ParticleT&)>;
+
+/**
+ * @brief A factory function: given params, returns a BiVarFn<ParticleT>
+ */
+template<typename ParticleT>
+using BiVarFactory = std::function<BiVarFn<ParticleT>(const std::vector<double>&)>;
+
+template<typename ParticleT>
+using BiVarFactoryRegistry = Registry<BiVarFactory<ParticleT>>;
+
 /**
  * @brief Bind a function to a specific parameter set.
  * @details This function binds a function to a specific parameter set. It uses
@@ -177,6 +213,25 @@ inline std::function<ValueT(const EventT&)> bind(const std::vector<double>& pars
         return [pars](const EventT& e){ return F(e, pars); };
     else
         return [=](const EventT& e){ return F(e); };
+}
+
+/**
+ * @brief Bind a bivariable function to a specific parameter set.
+ * @details This function binds a bivariable function (which takes two particles)
+ * to a specific parameter set. It uses std::is_invocable_v to check if the
+ * function can accept a vector of parameters.
+ * @tparam F The function to bind.
+ * @tparam ParticleT The type of particle.
+ * @param pars The parameters to bind to the function.
+ * @return A BiVarFn<ParticleT> that applies the bivariable to a pair of particles.
+ */
+template<auto F, typename ParticleT>
+inline BiVarFn<ParticleT> bind_bivar(const std::vector<double>& pars)
+{
+    if constexpr(std::is_invocable_v<decltype(F), const ParticleT&, const ParticleT&, const std::vector<double>&>)
+        return [pars](const ParticleT& a, const ParticleT& b){ return F(a, b, pars); };
+    else
+        return [=](const ParticleT& a, const ParticleT& b){ return F(a, b); };
 }
 
 /**
@@ -269,6 +324,39 @@ namespace                                                                       
         SelectorFactoryRegistry<RType>::instance().register_fn(                            \
             "reco_" #name, bind<fn<RType>, RType, size_t>                                  \
         );                                                                                 \
+        return true;                                                                       \
+    }();                                                                                   \
+}
+
+// Register a biselector for use in selecting a pair of particles within an
+// interaction.
+#define REGISTER_BISELECTOR(name, fn)                                                      \
+namespace                                                                                  \
+{                                                                                          \
+    const bool _reg_biselector_##name = []{                                                \
+        BiSelectorFactoryRegistry<TType>::instance().register_fn(                          \
+            "true_" #name, bind<fn<TType>, TType, std::pair<size_t, size_t>>               \
+        );                                                                                 \
+        BiSelectorFactoryRegistry<RType>::instance().register_fn(                          \
+            "reco_" #name, bind<fn<RType>, RType, std::pair<size_t, size_t>>               \
+        );                                                                                 \
+        return true;                                                                       \
+    }();                                                                                   \
+}
+
+// Register a bivariable with scope.
+#define REGISTER_BIVAR_SCOPE(scope, name, fn)                                              \
+namespace                                                                                  \
+{                                                                                          \
+    const bool _reg_bivar_##name = []{                                                     \
+        if constexpr((scope)==RegistrationScope::TrueParticle || (scope)==RegistrationScope::BothParticle) \
+            BiVarFactoryRegistry<TParticleType>::instance().register_fn(                   \
+                "true_particle_" #name, bind_bivar<fn<TParticleType>, TParticleType>       \
+            );                                                                             \
+        if constexpr((scope)==RegistrationScope::RecoParticle || (scope)==RegistrationScope::BothParticle) \
+            BiVarFactoryRegistry<RParticleType>::instance().register_fn(                   \
+                "reco_particle_" #name, bind_bivar<fn<RParticleType>, RParticleType>       \
+            );                                                                             \
         return true;                                                                       \
     }();                                                                                   \
 }

--- a/selection/include/framework.h
+++ b/selection/include/framework.h
@@ -335,10 +335,10 @@ namespace                                                                       
 {                                                                                          \
     const bool _reg_biselector_##name = []{                                                \
         BiSelectorFactoryRegistry<TType>::instance().register_fn(                          \
-            "true_" #name, bind<fn<TType>, TType, std::pair<size_t, size_t>>               \
+            "true_biselector_" #name, bind<fn<TType>, TType, std::pair<size_t, size_t>>    \
         );                                                                                 \
         BiSelectorFactoryRegistry<RType>::instance().register_fn(                          \
-            "reco_" #name, bind<fn<RType>, RType, std::pair<size_t, size_t>>               \
+            "reco_biselector_" #name, bind<fn<RType>, RType, std::pair<size_t, size_t>>    \
         );                                                                                 \
         return true;                                                                       \
     }();                                                                                   \
@@ -351,11 +351,11 @@ namespace                                                                       
     const bool _reg_bivar_##name = []{                                                     \
         if constexpr((scope)==RegistrationScope::TrueParticle || (scope)==RegistrationScope::BothParticle) \
             BiVarFactoryRegistry<TParticleType>::instance().register_fn(                   \
-                "true_particle_" #name, bind_bivar<fn<TParticleType>, TParticleType>       \
+                "true_bivar_" #name, bind_bivar<fn<TParticleType>, TParticleType>          \
             );                                                                             \
         if constexpr((scope)==RegistrationScope::RecoParticle || (scope)==RegistrationScope::BothParticle) \
             BiVarFactoryRegistry<RParticleType>::instance().register_fn(                   \
-                "reco_particle_" #name, bind_bivar<fn<RParticleType>, RParticleType>       \
+                "reco_bivar_" #name, bind_bivar<fn<RParticleType>, RParticleType>          \
             );                                                                             \
         return true;                                                                       \
     }();                                                                                   \

--- a/selection/include/variables.h
+++ b/selection/include/variables.h
@@ -26,6 +26,8 @@
 #include "include/utilities.h"
 #include "include/particle_utilities.h"
 #include "include/selectors.h"
+#include "include/biselectors.h"
+#include "include/bivariables.h"
 #include "framework.h"
 
 /**

--- a/selection/src/framework.cc
+++ b/selection/src/framework.cc
@@ -254,15 +254,15 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
         if(var.has_field("parameters"))
             varPars = var.get_double_vector("parameters");
 
-        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_particle"))
+        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_bivar"))
         {
             if(var.has_field("biselector"))
             {
-                std::string full_name = "true_" + var.get_string_field("biselector") + "_" + var_name;
-                std::string biselector_name = "true_" + var.get_string_field("biselector");
+                std::string full_name = "true_bivar_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "true_biselector_" + var.get_string_field("biselector");
                 auto biselector_factory = BiSelectorFactoryRegistry<TType>::instance().get(biselector_name);
                 auto biselector = biselector_factory(std::vector<double>{});
-                var_name = "true_particle_" + var_name;
+                var_name = "true_bivar_" + var_name;
                 auto factory = BiVarFactoryRegistry<TParticleType>::instance().get(var_name);
                 auto bivar_fn = factory(varPars);
                 VarFn<TType> var_fn_composed = [bivar_fn, biselector](const TType & e) -> double
@@ -322,15 +322,15 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
             }
         }
         
-        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_particle"))
+        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_bivar"))
         {
             if(var.has_field("biselector"))
             {
-                std::string full_name = "reco_" + var.get_string_field("biselector") + "_" + var_name;
-                std::string biselector_name = "reco_" + var.get_string_field("biselector");
+                std::string full_name = "reco_biselector_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "reco_biselector_" + var.get_string_field("biselector");
                 auto biselector_factory = BiSelectorFactoryRegistry<RType>::instance().get(biselector_name);
                 auto biselector = biselector_factory(std::vector<double>{});
-                var_name = "reco_particle_" + var_name;
+                var_name = "reco_bivar_" + var_name;
                 auto factory = BiVarFactoryRegistry<RParticleType>::instance().get(var_name);
                 auto bivar_fn = factory(varPars);
                 VarFn<RType> var_fn_composed = [bivar_fn, biselector](const RType & e) -> double
@@ -447,15 +447,15 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
         if(var.has_field("parameters"))
             varPars = var.get_double_vector("parameters");
 
-        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_particle"))
+        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_bivar"))
         {
             if(var.has_field("biselector"))
             {
-                std::string full_name = "true_" + var.get_string_field("biselector") + "_" + var_name;
-                std::string biselector_name = "true_" + var.get_string_field("biselector");
+                std::string full_name = "true_bivar_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "true_biselector_" + var.get_string_field("biselector");
                 auto biselector_factory = BiSelectorFactoryRegistry<TType>::instance().get(biselector_name);
                 auto biselector = biselector_factory(std::vector<double>{});
-                var_name = "true_particle_" + var_name;
+                var_name = "true_bivar_" + var_name;
                 auto factory = BiVarFactoryRegistry<TParticleType>::instance().get(var_name);
                 auto bivar_fn = factory(varPars);
                 VarFn<TType> var_fn_composed = [bivar_fn, biselector](const TType & e) -> double
@@ -514,15 +514,15 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
                     ismc));
             }
         }
-        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_particle"))
+        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_bivar"))
         {
             if(var.has_field("biselector"))
             {
-                std::string full_name = "reco_" + var.get_string_field("biselector") + "_" + var_name;
-                std::string biselector_name = "reco_" + var.get_string_field("biselector");
+                std::string full_name = "reco_bivar_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "reco_biselector_" + var.get_string_field("biselector");
                 auto biselector_factory = BiSelectorFactoryRegistry<RType>::instance().get(biselector_name);
                 auto biselector = biselector_factory(std::vector<double>{});
-                var_name = "reco_particle_" + var_name;
+                var_name = "reco_bivar_" + var_name;
                 auto factory = BiVarFactoryRegistry<RParticleType>::instance().get(var_name);
                 auto bivar_fn = factory(varPars);
                 VarFn<RType> var_fn_composed = [bivar_fn, biselector](const RType & e) -> double

--- a/selection/src/framework.cc
+++ b/selection/src/framework.cc
@@ -254,9 +254,29 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
         if(var.has_field("parameters"))
             varPars = var.get_double_vector("parameters");
 
-        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle"))
+        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_particle"))
         {
-            if(var.has_field("selector"))
+            if(var.has_field("biselector"))
+            {
+                std::string full_name = "true_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "true_" + var.get_string_field("biselector");
+                auto biselector_factory = BiSelectorFactoryRegistry<TType>::instance().get(biselector_name);
+                auto biselector = biselector_factory(std::vector<double>{});
+                var_name = "true_particle_" + var_name;
+                auto factory = BiVarFactoryRegistry<TParticleType>::instance().get(var_name);
+                auto bivar_fn = factory(varPars);
+                VarFn<TType> var_fn_composed = [bivar_fn, biselector](const TType & e) -> double
+                {
+                    auto [first_idx, second_idx] = biselector(e);
+                    if(first_idx == kNoMatch || second_idx == kNoMatch) return kNoMatchValue;
+                    return bivar_fn(e.particles[first_idx], e.particles[second_idx]);
+                };
+                return std::make_pair(full_name, spill_multivar_helper<TType, RType, TParticleType, TType>(
+                    true_cut,
+                    reco_cut_functions.empty() ? std::nullopt : std::optional<CutFn<RType>>(reco_cut),
+                    true_particle_cut, var_fn_composed, event_cut, ismc));
+            }
+            else if(var.has_field("selector"))
             {
                 // Full name for the variable.
                 std::string full_name = "true_" + var.get_string_field("selector") + "_" + var_name;
@@ -302,9 +322,29 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
             }
         }
         
-        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle"))
+        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_particle"))
         {
-            if(var.has_field("selector"))
+            if(var.has_field("biselector"))
+            {
+                std::string full_name = "reco_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "reco_" + var.get_string_field("biselector");
+                auto biselector_factory = BiSelectorFactoryRegistry<RType>::instance().get(biselector_name);
+                auto biselector = biselector_factory(std::vector<double>{});
+                var_name = "reco_particle_" + var_name;
+                auto factory = BiVarFactoryRegistry<RParticleType>::instance().get(var_name);
+                auto bivar_fn = factory(varPars);
+                VarFn<RType> var_fn_composed = [bivar_fn, biselector](const RType & e) -> double
+                {
+                    auto [first_idx, second_idx] = biselector(e);
+                    if(first_idx == kNoMatch || second_idx == kNoMatch) return kNoMatchValue;
+                    return bivar_fn(e.particles[first_idx], e.particles[second_idx]);
+                };
+                return std::make_pair(full_name, spill_multivar_helper<TType, RType, TParticleType, RType>(
+                    true_cut,
+                    reco_cut_functions.empty() ? std::nullopt : std::optional<CutFn<RType>>(reco_cut),
+                    true_particle_cut, var_fn_composed, event_cut, ismc));
+            }
+            else if(var.has_field("selector"))
             {
                 // Full name for the variable.
                 std::string full_name = "reco_" + var.get_string_field("selector") + "_" + var_name;
@@ -407,9 +447,29 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
         if(var.has_field("parameters"))
             varPars = var.get_double_vector("parameters");
 
-        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle"))
+        if(var_type == "true" || (var.has_field("selector") && var_type == "true_particle") || (var.has_field("biselector") && var_type == "true_particle"))
         {
-            if(var.has_field("selector"))
+            if(var.has_field("biselector"))
+            {
+                std::string full_name = "true_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "true_" + var.get_string_field("biselector");
+                auto biselector_factory = BiSelectorFactoryRegistry<TType>::instance().get(biselector_name);
+                auto biselector = biselector_factory(std::vector<double>{});
+                var_name = "true_particle_" + var_name;
+                auto factory = BiVarFactoryRegistry<TParticleType>::instance().get(var_name);
+                auto bivar_fn = factory(varPars);
+                VarFn<TType> var_fn_composed = [bivar_fn, biselector](const TType & e) -> double
+                {
+                    auto [first_idx, second_idx] = biselector(e);
+                    if(first_idx == kNoMatch || second_idx == kNoMatch) return kNoMatchValue;
+                    return bivar_fn(e.particles[first_idx], e.particles[second_idx]);
+                };
+                return std::make_pair(full_name, spill_multivar_helper<RType, TType, TParticleType, TType>(
+                    reco_cut,
+                    true_cut_functions.empty() ? std::nullopt : std::optional<CutFn<TType>>(true_cut),
+                    true_particle_cut, var_fn_composed, event_cut, ismc));
+            }
+            else if(var.has_field("selector"))
             {
                 // Full name for the variable.
                 std::string full_name = "true_" + var.get_string_field("selector") + "_" + var_name;
@@ -454,9 +514,29 @@ NamedSpillMultiVar construct(const std::vector<cfg::ConfigurationTable> & cuts,
                     ismc));
             }
         }
-        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle"))
+        else if(var_type == "reco" || (var.has_field("selector") && var_type == "reco_particle") || (var.has_field("biselector") && var_type == "reco_particle"))
         {
-            if(var.has_field("selector"))
+            if(var.has_field("biselector"))
+            {
+                std::string full_name = "reco_" + var.get_string_field("biselector") + "_" + var_name;
+                std::string biselector_name = "reco_" + var.get_string_field("biselector");
+                auto biselector_factory = BiSelectorFactoryRegistry<RType>::instance().get(biselector_name);
+                auto biselector = biselector_factory(std::vector<double>{});
+                var_name = "reco_particle_" + var_name;
+                auto factory = BiVarFactoryRegistry<RParticleType>::instance().get(var_name);
+                auto bivar_fn = factory(varPars);
+                VarFn<RType> var_fn_composed = [bivar_fn, biselector](const RType & e) -> double
+                {
+                    auto [first_idx, second_idx] = biselector(e);
+                    if(first_idx == kNoMatch || second_idx == kNoMatch) return kNoMatchValue;
+                    return bivar_fn(e.particles[first_idx], e.particles[second_idx]);
+                };
+                return std::make_pair(full_name, spill_multivar_helper<RType, TType, RParticleType, RType>(
+                    reco_cut,
+                    true_cut_functions.empty() ? std::nullopt : std::optional<CutFn<TType>>(true_cut),
+                    reco_particle_cut, var_fn_composed, event_cut, ismc));
+            }
+            else if(var.has_field("selector"))
             {
                 // Full name for the variable.
                 std::string full_name = "reco_" + var.get_string_field("selector") + "_" + var_name;
@@ -859,3 +939,11 @@ template class Registry<VarFactory<EventType>>;
 // Explicit instantiation for selector registries
 template class Registry<SelectorFactory<TType>>;
 template class Registry<SelectorFactory<RType>>;
+
+// Biselector Registry
+template class Registry<BiSelectorFactory<TType>>;
+template class Registry<BiSelectorFactory<RType>>;
+
+// Bivariable Registry
+template class Registry<BiVarFactory<TParticleType>>;
+template class Registry<BiVarFactory<RParticleType>>;

--- a/selection/src/main.cc
+++ b/selection/src/main.cc
@@ -22,11 +22,13 @@
 #include "scorers.h"
 #include "cuts.h"
 #include "variables.h"
+#include "bivariables.h"
 #include "mctruth.h"
 #include "event_cuts.h"
 #include "event_variables.h"
 #include "spill_cuts.h"
 #include "selectors.h"
+#include "biselectors.h"
 #include "analysis.h"
 
 std::shared_ptr<VarFn<RParticleType>> pvars::primfn = std::make_shared<VarFn<RParticleType>>(pvars::default_primary_classification<RParticleType>);
@@ -241,11 +243,20 @@ int main(int argc, char * argv[])
                         vars_map.try_emplace(thisvar_true.first, thisvar_true.second);
                         vars_map.try_emplace(thisvar_reco.first, thisvar_reco.second);
                     }
+                    else if(var.get_string_field("type") == "both_bivar")
+                    {
+                        NamedSpillMultiVar thisvar_true = construct(cuts, var, mode, "true_bivar", sample.get_bool_field("ismc"));
+                        NamedSpillMultiVar thisvar_reco = construct(cuts, var, mode, "reco_bivar", sample.get_bool_field("ismc"));
+                        vars_map.try_emplace(thisvar_true.first, thisvar_true.second);
+                        vars_map.try_emplace(thisvar_reco.first, thisvar_reco.second);
+                    }
                     else if(var.get_string_field("type") == "true"
                             || var.get_string_field("type") == "reco"
                             || var.get_string_field("type") == "mctruth"
                             || var.get_string_field("type") == "true_particle"
                             || var.get_string_field("type") == "reco_particle"
+                            || var.get_string_field("type") == "true_bivar"
+                            || var.get_string_field("type") == "reco_bivar"
                             || var.get_string_field("type") == "event")
                     {
                         NamedSpillMultiVar thisvar = construct(cuts, var, mode, var.get_string_field("type"), sample.get_bool_field("ismc"));

--- a/tutorial/tutorial.md
+++ b/tutorial/tutorial.md
@@ -272,6 +272,45 @@ Each entry in the `branch` list defines a variable to be extracted from the sele
 
 The user has the duty to ensure that all branch variables are of the same length. Particle-level and interaction-level branches cannot be mixed in the same tree, as this will lead to a mismatch in the number of entries and a thrown exception.
 
+#### Biselectors and Bivariables
+
+Many analyses require computing observables that depend on *two* particles within an interaction — for example, the opening angle between a muon and a proton. The standard `selector` mechanism identifies a single particle; **biselectors** extend this pattern to particle pairs.
+
+A **biselector** is a function that receives an interaction object and returns the indices of exactly two particles (as a `std::pair<size_t, size_t>`). A **bivariable** is a function that receives those two particles and returns a `double`. Together they allow interaction-level branch variables to capture two-particle kinematics in a one-to-one correspondence with the interaction entry — no particle-level loop is needed.
+
+##### Using a Biselector in the Configuration
+
+To use a biselector, specify `type = "reco_bivar"` (or `"true_bivar"`) and add a `biselector` field naming the desired biselector:
+
+```toml
+branch = [
+    { name = "opening_angle", type = "reco_bivar", biselector = "muon_proton"      },
+]
+```
+
+The `name` field now identifies a **bivariable** function instead of a standard branch variable function. As with ordinary branches, an optional `parameters` list may be supplied if the bivariable accepts configurable arguments.
+
+##### Full Example
+
+The snippet below adds two-particle observables to a CCQE-like selection. Both the reconstructed and true versions are extracted through the shortcut of `type = "both_bivar"`, which creates two branches with the same name but different types. The `muon_proton` biselector identifies the leading muon and leading proton in the interaction, and the `opening_angle` bivariable computes the opening angle between those two particles.
+
+```toml
+[[tree]]
+name = "selected"
+sim_only = false
+mode = "reco"
+cut = [
+    { name = "fiducial_cut",     type = "reco" },
+    { name = "containment_cut",  type = "reco" },
+    { name = "single_muon",      type = "reco", parameters = [ "@muon_threshold"    ] },
+    { name = "single_proton",    type = "reco", parameters = [ "@proton_threshold"  ] },
+]
+branch = [
+    { name = "neutrino_energy",  type = "mctruth"   },
+    { name = "opening_angle",    type = "both_bivar", biselector = "muon_proton" },
+]
+```
+
 ### Category Block Configuration
 The `category` blocks are optional sections that allow the user to define named categories for interactions at the truth level. These categories can be used to classify interactions based on specific criteria, such as interaction type or final state particle content. Each `category` block defines a single category through application of a series of cuts. The categories are assigned in order of appearance in the configuration file, with the first category that an interaction passes being assigned to that interaction. If an interaction does not pass any category, it is assigned a default category of NaN. The user is responsible for ensuring that the defined categories are mutually exclusive and collectively exhaustive.
 


### PR DESCRIPTION
Extends the selector/particle-variable pattern to operate on pairs of particles. A biselector returns std::pair<size_t, size_t> (two particle indices from an interaction), and a bivariable computes a double from two particles — enabling two-particle observables to be broadcast to the interaction level, just as single-particle variables are today via selectors.