### PR TITLE
Relaunch Jobs for Missing Files

### DIFF
--- a/batch/medulla.py
+++ b/batch/medulla.py
@@ -17,6 +17,7 @@ def main(
     memory : int = 1800,
     disk : Optional[int] = None,
     lifetime : str = '1h',
+    relaunch_missing : bool = False,
 ):
     """
     Main function to run the medulla script.
@@ -48,7 +49,9 @@ def main(
     disk : int | None
         Amount of disk to request for each job in GB. If None, use default.
     lifetime : str
-        Expected lifetime of each job (e.g., '1h', '30m'). 
+        Expected lifetime of each job (e.g., '1h', '30m').
+    relaunch_missing : bool
+        If True, relaunch jobs that are in project.db but missing output files.
 
     Returns
     -------
@@ -79,13 +82,13 @@ def main(
     if test_job:
         if not project_exists:
             raise FileNotFoundError(f"Project database {project_dir / 'project.db'} does not exist. Please create a new project first.")
-        launch_jobsub(project_dir, experiment, njobs=1, tag=tag, memory=memory, disk=disk, lifetime=lifetime)
+        launch_jobsub(project_dir, experiment, njobs=1, tag=tag, memory=memory, disk=disk, lifetime=lifetime, relaunch_missing=relaunch_missing)
 
     # If the user requested to launch jobs, do so.
     if launch_jobs is not None:
         if not project_exists:
             raise FileNotFoundError(f"Project database {project_dir / 'project.db'} does not exist. Please create a new project first.")
-        launch_jobsub(project_dir, experiment, njobs=launch_jobs, tag=tag, memory=memory, disk=disk, lifetime=lifetime)
+        launch_jobsub(project_dir, experiment, njobs=launch_jobs, tag=tag, memory=memory, disk=disk, lifetime=lifetime, relaunch_missing=relaunch_missing)
 
 if __name__ == '__main__':
     p = ArgumentParser(description='Run medulla.')
@@ -140,6 +143,11 @@ if __name__ == '__main__':
         '--launch-jobs', '-l', type=int, nargs='?', const=-1,
         help='Launch the specified number of jobs. If no number is provided, '
              'then all pending jobs will be launched.'
+    )
+
+    p.add_argument(
+        '--relaunch-missing', '-r', action='store_true',
+        help='Also relaunch jobs tracked in project.db but missing output files.'
     )
 
     p.add_argument(
@@ -199,4 +207,5 @@ if __name__ == '__main__':
         memory=args.memory,
         disk=args.disk,
         lifetime=args.lifetime,
+        relaunch_missing=args.relaunch_missing,
     )

--- a/batch/submit.sh
+++ b/batch/submit.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 #######################################################################
-# Usage: submit.sh [--project=PROJECT] [--tag=TAG]
-#
+# Usage: submit.sh [--project=PROJECT] [--tag=TAG]# 
 # Arguments:
 #   --project=PROJECT   : Specify the project directory
 #   --tag=TAG           : Git ref to checkout on grid nodes (default: develop)
@@ -88,7 +87,7 @@ ups active
 # Build medulla
 git clone https://github.com/justinjmueller/medulla.git
 cd medulla
-git checkout ${TAG}
+git checkout "${TAG}"
 mkdir build && cd build
 export CC=$(which gcc)
 export CXX=$(which g++)

--- a/batch/submit.sh
+++ b/batch/submit.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #######################################################################
-# Usage: submit.sh [--project=PROJECT] [--tag=TAG]# 
+# Usage: submit.sh [--project=PROJECT] [--tag=TAG]
+#
 # Arguments:
 #   --project=PROJECT   : Specify the project directory
 #   --tag=TAG           : Git ref to checkout on grid nodes (default: develop)

--- a/batch/utilities.py
+++ b/batch/utilities.py
@@ -323,6 +323,24 @@ def check_project_status(
     # complete. This helps avoid marking jobs as complete if they
     # failed and produced an empty output file.
     output_files = glob(str(project_dir / 'output' / 'output_jobid*.root'))
+    output_jobids = {
+        int(Path(f).stem.split('jobid')[-1])
+        for f in output_files
+    }
+
+    # Find jobs tracked in project.db that do not have a corresponding
+    # output file in output/.
+    command(curs, "SELECT jobid, status FROM jobs")
+    db_rows = curs.fetchall()
+    db_jobids = {row[0] for row in db_rows}
+    status_by_jobid = {row[0]: row[1] for row in db_rows}
+
+    missing_output_jobs = sorted(db_jobids - output_jobids)
+    missing_output_nonpending = [
+        jid for jid in missing_output_jobs
+        if status_by_jobid.get(jid) != 'pending'
+    ]
+
     completed_jobs = [
         int(Path(f).stem.split('jobid')[-1])
         for f in output_files if Path(f).stat().st_size >= 1024
@@ -330,8 +348,7 @@ def check_project_status(
     ins = [('completed', jid) for jid in completed_jobs]
     command(curs, "UPDATE jobs SET status = ? WHERE jobid = ?", ins)
     conn.commit()
-    conn.close()
-
+    
     stub_jobs = [
         int(Path(f).stem.split("jobid")[-1])
         for f in output_files
@@ -355,11 +372,28 @@ def check_project_status(
                     stub_file.unlink()
             print(f"[INFO] -- Deleted {len(stub_jobs)} stub output file(s).")
 
+    if missing_output_jobs:
+        print(
+            f"[INFO] -- Found {len(missing_output_jobs)} job(s) present in project.db"
+            " but missing output files in output/."
+        )
+        print(f"[INFO] -- Missing output job IDs: {missing_output_jobs}")
+    else:
+        print("[INFO] -- No jobs are missing output files (project.db and output/ are in sync).")
+
+    if missing_output_nonpending:
+        print(
+            f"[WARN] -- {len(missing_output_nonpending)} missing-output job(s) are"
+            " not pending; these may need investigation/resubmission."
+        )
+        print(f"[WARN] -- Non-pending missing output job IDs: {missing_output_nonpending}")
+
+    conn.close()
+
     # Replace the project database copy with the updated version.
     subprocess.run(['mv', './project.db', project_dir / 'project.db'], check=True)
 
     print(f"[INFO] -- Found {len(completed_jobs)} completed jobs.")
-
 def launch_jobsub(
     project_dir : str,
     exp : str = 'sbnd',
@@ -369,6 +403,7 @@ def launch_jobsub(
     memory : int = 1800,
     disk : Optional[int] = None,
     lifetime : str = '1h',
+    relaunch_missing : bool = False,
 ):
     """
     Launch jobs using jobsub for the given project directory. If njobs
@@ -394,6 +429,9 @@ def launch_jobsub(
         Amount of disk to request for each job in GB. If None, use default.
     lifetime : str
         Expected lifetime of each job (e.g., '1h', '30m'). If None, use default.
+    relaunch_missing : bool
+        If True, jobs found in project.db but missing output files in output/
+        are reset to 'pending' so they can be relaunched.
 
     Returns
     -------
@@ -408,10 +446,38 @@ def launch_jobsub(
     conn = sqlite3.connect('./project.db')
     curs = conn.cursor()
 
-    # Get the list of pending jobs.
-    command(curs, "SELECT jobid FROM jobs WHERE status = 'pending'")
-    pending_jobs = [row[0] for row in curs.fetchall()]
+    # Get the list of jobs from the DB and derive pending jobs.
+    command(curs, "SELECT jobid, status FROM jobs")
+    db_rows = curs.fetchall()
+    db_jobids = {row[0] for row in db_rows}
+    status_by_jobid = {row[0]: row[1] for row in db_rows}
+    pending_jobs = [jid for jid, status in db_rows if status == 'pending']
+
+    # Optionally relaunch jobs tracked in project.db but missing output files.
+    if relaunch_missing:
+        output_files = glob(str(project_dir / 'output' / 'output_jobid*.root'))
+        output_jobids = {
+            int(Path(f).stem.split('jobid')[-1])
+            for f in output_files
+        }
+        missing_output_jobs = sorted(db_jobids - output_jobids)
+        relaunch_jobs = [
+            jid for jid in missing_output_jobs
+            if status_by_jobid.get(jid) != 'pending'
+        ]
+        if relaunch_jobs:
+            ins = [('pending', jid) for jid in relaunch_jobs]
+            command(curs, "UPDATE jobs SET status = ? WHERE jobid = ?", ins)
+            conn.commit()
+            pending_jobs = sorted(set(pending_jobs).union(relaunch_jobs))
+            print(
+                f"[INFO] -- Marked {len(relaunch_jobs)} missing-output job(s) as pending for relaunch: {relaunch_jobs}"
+            )
+        else:
+            print("[INFO] -- No additional missing-output jobs needed relaunch.")
+
     conn.close()
+    subprocess.run(['mv', './project.db', project_dir / 'project.db'], check=True)
 
     # Do some checking that the request is sane. Naturally, if there
     # are no pending jobs, there is nothing to launch. Similarly, if
@@ -430,6 +496,10 @@ def launch_jobsub(
 
     if confirm:
         print(f"{_INFO} -- Found {len(pending_jobs)} pending jobs.")
+
+    disk_size = '10GB' if exp == 'sbnd' else '25GB'
+    if disk is not None:
+        disk_size = f'{disk}GB'
 
     # Form the jobsub command to launch the jobs.
     cmd = [

--- a/batch/utilities.py
+++ b/batch/utilities.py
@@ -348,7 +348,7 @@ def check_project_status(
     ins = [('completed', jid) for jid in completed_jobs]
     command(curs, "UPDATE jobs SET status = ? WHERE jobid = ?", ins)
     conn.commit()
-    
+
     stub_jobs = [
         int(Path(f).stem.split("jobid")[-1])
         for f in output_files


### PR DESCRIPTION
This PR adds a feature to relaunch batch jobs if the output files are missing or corrupted (via a IsZombie root file call). This feature can be used via the command line "--relaunch-missing" argument