### PR TITLE
Fix Tag ArgParse

### DIFF
--- a/batch/medulla.py
+++ b/batch/medulla.py
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     )
 
     p.add_argument(
-        '--tag', '-t', type=str, default='develop',
+        '--tag', type=str, default='develop',
         help='Tag to use for the medulla repository (defaults to develop).'
     )
 


### PR DESCRIPTION
medulla batch file had a parse args bug introduced, 2 parameters defined as -t. Removed from new --tag argument